### PR TITLE
allowing multiple calls to cxy_ctl:init/1

### DIFF
--- a/src/cxy_ctl.erl
+++ b/src/cxy_ctl.erl
@@ -126,7 +126,10 @@ make_proc_params(Acc, Type, Max_Procs, Max_History) ->
     
 do_init(Buffer_Params, Cxy_Params) ->
     ets_buffer:create(Buffer_Params),
-    _ = ets:new(?MODULE, [named_table, ordered_set, public, {write_concurrency, true}]),
+    case ets:info(?MODULE, named_table) of
+        undefined -> _ = ets:new(?MODULE, [named_table, ordered_set, public, {write_concurrency, true}]);
+        _ -> ok
+    end,
     _ = [ets:insert_new(?MODULE, Proc_Values) || Proc_Values <- Cxy_Params],
     ok.
 

--- a/test/dk_cxy/cxy_ctl_SUITE.erl
+++ b/test/dk_cxy/cxy_ctl_SUITE.erl
@@ -9,7 +9,8 @@
          check_concurrency_types/1,
          check_execute_task/1,        check_maybe_execute_task/1,
          check_execute_pid_link/1,    check_maybe_execute_pid_link/1,
-         check_execute_pid_monitor/1, check_maybe_execute_pid_monitor/1
+         check_execute_pid_monitor/1, check_maybe_execute_pid_monitor/1,
+         check_multiple_init_calls/1
         ]).
 
 %% Spawned functions
@@ -25,7 +26,8 @@ all() -> [
           check_concurrency_types,
           check_execute_task,        check_maybe_execute_task,
           check_execute_pid_link,    check_maybe_execute_pid_link,
-          check_execute_pid_monitor, check_maybe_execute_pid_monitor
+          check_execute_pid_monitor, check_maybe_execute_pid_monitor,
+          check_multiple_init_calls
          ].
 
 -type config() :: proplists:proplist().
@@ -320,6 +322,17 @@ check_maybe_execute_pid_monitor(_Config) ->
     after put(joe, Old_Joe)
     end,
 
+    ok.
+
+-spec check_multiple_init_calls(proplists:proplist()) -> ok.
+check_multiple_init_calls(_Config) ->
+    Limits = [{a, unlimited, 0}, {b, 17, 5}, {c, 8, 0}, {d, inline_only, 7}],
+    [ok = ?TM:init([L]) || L <- Limits],
+    Types = ?TM:concurrency_types(),
+    [[a, -1, 0, 0], [b, 17, 0, 5], [c, 8, 0, 0], [d, 0, 0, 7]]
+        = [[proplists:get_value(P, This_Type_Props)
+            || P <- [task_type, max_procs, active_procs, max_history]]
+           || This_Type_Props <- Types],
     ok.
 
 -spec put_pdict(atom(), any()) -> {get_pdict, pid(), any()}.


### PR DESCRIPTION
Hey :)

I have the following use case, where an application has multiple dependencies trying to set their own concurrency limits. I've figured that it wouldn't hurt to allow multiple calls to cxy_ctl:init/1, so each dependency could allow its own concurrency limits along the way (and/or adding limits when needed, instead of being a one-time only operation).

Makes sense?
