### PR TITLE
Maintain per-type high water process count in cxy_ctl.

### DIFF
--- a/src/batch_feeder.erl
+++ b/src/batch_feeder.erl
@@ -79,10 +79,10 @@ process_data({Module, _Env} = Context) ->
 process_batch(Iteration, This_Batch, {Module, _Env} = Context, Continuation_Fn) ->
     try
         {Prepped_Batch, Context2} = Module:prep_batch(Iteration, This_Batch, Context),
-        {Reply, Context3} = case Module:exec_batch(Iteration, Prepped_Batch, Context2) of
-                                {error, Reason} = Err -> {Err, Context2};
-                                {ok, Context2a}       -> {ok, Context2a}
-                            end,
+        {_Reply, Context3} = case Module:exec_batch(Iteration, Prepped_Batch, Context2) of
+                                 {error, _Reason} = Err -> {Err, Context2};
+                                 {ok, Context2a}        -> {ok, Context2a}
+                             end,
         Next_Iteration = Iteration+1,
         case Continuation_Fn(Next_Iteration, Context3) of
             done -> done;


### PR DESCRIPTION
Hi Jay. You may remember me from our TRW days. I now work with Anthony Molinaro at OpenX and he told me about your epoxcy library. We recently realized that we want to run a function asynchronously but limit how many concurrent executions are allowed and the concurrency control functions in epocxy seemed like a good fit. We also log stats about the service state once a minute, and I wanted to record the maximum number of concurrent processes in the last minute so I modified cxy_ctl to do that. I hope that you find my changes to support that useful.

Adds a `cxy_ctl:high_water` function, which returns the maximum number of concurrent processes run by cxy_ctl:execute_task family of functions. The one-argument form just returns the value, while the two-argument form also atomically resets the high-water mark.