### PR TITLE
Delete cache before create so cxy_cache_fsm restart succeeds

### DIFF
--- a/src/cxy_cache_sup.erl
+++ b/src/cxy_cache_sup.erl
@@ -46,7 +46,6 @@
 
 start_link() -> supervisor:start_link({local, ?SERVER}, ?MODULE, {}).
 
-
 %% Start a non-generational cache (all data fits in memory).
 start_cache(Cache_Name, Cache_Mod)
   when is_atom(Cache_Name), is_atom(Cache_Mod) ->
@@ -84,8 +83,8 @@ start_cache(Cache_Name, Cache_Mod, Type, Threshold)
 
 -spec init({}) -> sup_init_return().
 
--define(CHILD(__Mod, __Args), {__Mod, {__Mod, start_link, __Args}, temporary, 2000, worker, [__Mod]}).
+-define(CHILD(__Mod, __Args), {__Mod, {__Mod, start_link, __Args}, transient, 2000, worker, [__Mod]}).
 
 init({}) ->
     Cache_Fsm = ?CHILD(cxy_cache_fsm, []),
-    {ok, { {simple_one_for_one, 5, 60}, [Cache_Fsm]} }.
+    {ok, { {simple_one_for_one, 5, 10}, [Cache_Fsm]} }.


### PR DESCRIPTION
cxy_cache_fsm exists solely to own the ets generational
tables for a cache. If it stops, the cache tables will be
automatically deleted. So the stop clause needed to delete
the cache metadata from the ets table it doesn't own.

A more complicated situation arises when cxy_cache_fsm
restarts. It may have died in a way that prevented terminate
from running, so the ets tables are gone, but the metadata
is still present. The sledgehammer approach is to use the
cxy_cache_sup:start_link function to delete a cache before
it instantiates a new cxy_cache_fsm instance. In addition,
the FSM children were changed to transient so that they
get restarted if they fail.

If this behavior is not wanted, call cxy_cache_fsm:start_link
directly rather than via cxy_cache_sup, or roll your own
cxy_cache_sup to change the initialization sequence.