### PR TITLE
Require 3 slabs to avoid issues/75

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 Erlang Patterns of Concurrency (epocxy)
 =======================================
 
+The version number format epocxy uses is Major.Minor.Rev (e.g., 1.1.0). If the Rev is an even number, this is a release version and will be tagged for builds. If it is an odd number, it is a modification of Master that is under development but available for testing, and will only be marked in the epocxy.app file, not as a tagged version. Only use Master in your dependency if you are testing partial fixes; always use an even number tag starting with 1.1.0 for stable release dependency.
+
 NOTE:
-  - Please use tags when including this library. The master branch may contain partial or incomplete new features if you use the latest HEAD.
   - 'make tests' is significantly slower in 1.1.0 because of cxy_fount PropEr tests. Enchancements are planned to speed testing in 1.1.1. Production performance is not impacted. Update: cxy_fount_SUITE now takes 30 seconds on my laptop, it won't get any faster.
   - cxy_regulator gives intermittent failures when running 'make tests'. This is a timing issue in the test itself. Run again and/or stop some CPU intensive operations before running. Hoping to fix this in 1.1.1
 

--- a/src/cxy_fount.erl
+++ b/src/cxy_fount.erl
@@ -204,7 +204,7 @@ parse_options(Fount_Options) ->
             notifier  = proplists:get_value(notifier,  Fount_Options, no_notifier)
            } of
         #parsed_fount_options{slab_size=SS}     when SS =< 0   -> {error, {slab_size, SS}};
-        #parsed_fount_options{num_slabs=NS}     when NS  < 2   -> {error, {num_slabs, NS}};
+        #parsed_fount_options{num_slabs=NS}     when NS  < 3   -> {error, {num_slabs, NS}};
         #parsed_fount_options{notifier=N} = PFO when is_pid(N) -> PFO;
         #parsed_fount_options{notifier=no_notifier} = PFO      -> PFO
     end.

--- a/src/epocxy.app.src
+++ b/src/epocxy.app.src
@@ -6,7 +6,7 @@
 {application, epocxy,
  [
   {id, "epocxy"},
-  {vsn, "1.1.0"},
+  {vsn, "1.1.1"},
   {description, "Erlang Patterns of Concurrency"},
   {modules,      [
                   batch_feeder,

--- a/test/epocxy/cxy_fount_SUITE.erl
+++ b/test/epocxy/cxy_fount_SUITE.erl
@@ -86,7 +86,7 @@ check_construction(_Config) ->
     Test = "Check that founts can be constructed and refill fully",
     ct:comment(Test), ct:log(Test),
 
-    Full_Fn = ?FORALL({Slab_Size, Depth}, {range(1,37), range(2,17)},
+    Full_Fn = ?FORALL({Slab_Size, Depth}, {range(1,37), range(3,17)},
                       verify_full_fount(Slab_Size, Depth)),
     true = proper:quickcheck(Full_Fn, ?PQ_NUM(5)),
 
@@ -243,7 +243,7 @@ check_reservoir_refills(_Config) ->
 
     Test_Allocators = 
         ?FORALL({Slab_Size, Depth, Num_Pids},
-                {range(1,20), range(2,10), non_empty(list(range(1, 30)))},
+                {range(1,20), range(3,10), non_empty(list(range(1, 30)))},
                 verify_slab_refills(Slab_Size, Depth, Num_Pids)),
     true = proper:quickcheck(Test_Allocators, ?PQ_NUM(100)),
 


### PR DESCRIPTION
Issue #75 pointed out that a reservoir with 2 slabs will often not provide pids if you ask for more than 1 slabs worth of pids. This is mainly a configuration sizing issue that the slab size should be larger than the majority of requests, but by requiring all reservoirs to have at least 3 slabs, we can avoid most situations where more than a slab causes a problem. There will still be bad behavior when the slab size is small but larger than 1 because partially filled slabs are not considered empty and won't have replacements spawned. It is probably good practice to not exceed 2 slabs when asking for a group of pids (make more than one request if that many are needed).